### PR TITLE
Chores/update highline and spec dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    rawline (0.3.2)
+      highline (>= 1.7.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    highline (1.7.2)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.1)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rawline!
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.10.4

--- a/rawline.gemspec
+++ b/rawline.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.files += Dir.glob("examples/*")
   s.files += Dir.glob("spec/*")
   s.files += ["README.rdoc", "LICENSE", "CHANGELOG.rdoc"]
-	s.add_runtime_dependency("highline", [">= 1.4.0"])
+	s.add_runtime_dependency("highline", [">= 1.7.2"])
 end

--- a/rawline.gemspec
+++ b/rawline.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.files += Dir.glob("spec/*")
   s.files += ["README.rdoc", "LICENSE", "CHANGELOG.rdoc"]
 	s.add_runtime_dependency("highline", [">= 1.7.2"])
+  s.add_development_dependency("rspec", ["~> 3.0"])
 end

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -24,8 +24,8 @@ describe RawLine::Editor do
 		@input << "test #1"
 		@input.rewind
 	 	@editor.read
-		@editor.line.text.should == "test #1"
-		@output.string.should == "test #1\n"
+		expect(@editor.line.text).to eq("test #1")
+		expect(@output.string).to eq("test #1\n")
 	end
 
 	it "can bind keys to code blocks" do
@@ -34,35 +34,35 @@ describe RawLine::Editor do
 		@editor.bind(21) { "test #2c" }
 		@editor.bind([22]) { "test #2d" }
 		@editor.terminal.escape_codes = [] # remove any existing escape codes
-		lambda {@editor.bind({:test => [?\e.ord, ?t.ord, ?e.ord, ?s.ord, ?t.ord]}) { "test #2e" }}.should raise_error(RawLine::BindingException)
+		expect {@editor.bind({:test => [?\e.ord, ?t.ord, ?e.ord, ?s.ord, ?t.ord]}) { "test #2e" }}.to raise_error
 		@editor.terminal.escape_codes << ?\e.ord
-		lambda {@editor.bind({:test => "\etest"}) { "test #2e" }}.should_not raise_error(RawLine::BindingException)
-		lambda {@editor.bind("\etest2") { "test #2f" }}.should_not raise_error(RawLine::BindingException)
+		expect {@editor.bind({:test => "\etest"}) { "test #2e" }}.to_not raise_error
+		expect {@editor.bind("\etest2") { "test #2f" }}.to_not raise_error
 		@input << ?\C-w.chr
 		@input.rewind
 	 	@editor.read
-		@editor.line.text.should == "test #2a"
+		expect(@editor.line.text).to eq("test #2a")
 		@editor.char = [?\C-q.ord]
-		@editor.press_key.should == "test #2b"
+		expect(@editor.press_key).to eq("test #2b")
 		@editor.char = [?\C-u.ord]
-		@editor.press_key.should == "test #2c"
+		expect(@editor.press_key).to eq("test #2c")
 		@editor.char = [?\C-v.ord]
-		@editor.press_key.should == "test #2d"
+		expect(@editor.press_key).to eq("test #2d")
 		@editor.char = [?\e.ord, ?t.ord, ?e.ord, ?s.ord, ?t.ord]
-		@editor.press_key.should == "test #2e"
+		expect(@editor.press_key).to eq("test #2e")
 		@editor.char = [?\e.ord, ?t.ord, ?e.ord, ?s.ord, ?t.ord, ?2.ord]
-		@editor.press_key.should == "test #2f"
+		expect(@editor.press_key).to eq("test #2f")
 	end
 
 	it "keeps track of the cursor position" do
 		@input << "test #4"
 		@input.rewind
 		@editor.read
-		@editor.line.position.should == 7
+		expect(@editor.line.position).to eq(7)
 		3.times { @editor.move_left }
-		@editor.line.position.should == 4
+		expect(@editor.line.position).to eq(4)
 		2.times { @editor.move_right }
-		@editor.line.position.should == 6
+		expect(@editor.line.position).to eq(6)
 	end
 
 	it "can delete characters" do
@@ -72,8 +72,8 @@ describe RawLine::Editor do
 		3.times { @editor.move_left }
 		4.times { @editor.delete_left_character }
 		3.times { @editor.delete_character }
-		@editor.line.text.should == ""
-		@editor.line.position.should == 0
+		expect(@editor.line.text).to eq("")
+		expect(@editor.line.position).to eq(0)
 	end
 
 	it "can clear the whole line" do
@@ -81,8 +81,8 @@ describe RawLine::Editor do
 		@input.rewind
 		@editor.read
 		@editor.clear_line
-		@editor.line.text.should == ""
-		@editor.line.position.should == 0
+		expect(@editor.line.text).to eq("")
+		expect(@editor.line.position).to eq(0)
 	end
 
 	it "supports undo and redo" do
@@ -91,9 +91,9 @@ describe RawLine::Editor do
 		@editor.read
 		3.times { @editor.delete_left_character }
 		2.times { @editor.undo }
-		@editor.line.text.should == "test #"
+		expect(@editor.line.text).to eq("test #")
 		2.times { @editor.redo }
-		@editor.line.text.should == "test"
+		expect(@editor.line.text).to eq("test")
 	end
 
 	it "supports history" do
@@ -114,11 +114,11 @@ describe RawLine::Editor do
 		@editor.read "", true
 		@editor.newline
 		@editor.history_back
-		@editor.line.text.should == "test #7c"
+		expect(@editor.line.text).to eq("test #7c")
 		10.times { @editor.history_back }
-		@editor.line.text.should == "test #7a"
+		expect(@editor.line.text).to eq("test #7a")
 		2.times { @editor.history_forward }
-		@editor.line.text.should == "test #7c"
+		expect(@editor.line.text).to eq("test #7c")
 	end
 
 	it "can overwrite lines" do
@@ -126,8 +126,8 @@ describe RawLine::Editor do
 		@input.rewind
 		@editor.read
 		@editor.overwrite_line("test #8b", 2)
-		@editor.line.text.should == "test #8b"
-		@editor.line.position.should == 2
+		expect(@editor.line.text).to eq("test #8b")
+		expect(@editor.line.position).to eq(2)
 	end
 
 	it "can complete words" do
@@ -141,25 +141,24 @@ describe RawLine::Editor do
 		@input << "test #9 de" << ?\t.chr << ?\t.chr
 		@input.rewind
 		@editor.read
-		@editor.line.text.should == "test #9 delete\t"
+		expect(@editor.line.text).to eq("test #9 delete\t")
 	end
 
 	it "supports INSERT and REPLACE modes" do
-		@input << "test 0" 
+		@input << "test 0"
 		@editor.terminal.keys[:left_arrow].each { |k| @input << k.chr }
 		@input << "#1"
 		@input.rewind
 		@editor.read
-		@editor.line.text.should == "test #10"
+		expect(@editor.line.text).to eq("test #10")
 		@editor.toggle_mode
-		@input << "test 0" 
+		@input << "test 0"
 		@editor.terminal.keys[:left_arrow].each { |k| @input << k.chr }
 		@input << "#1"
 		@input.rewind
 		@editor.read
-		@editor.line.text.should == "test #1test #1"
+		expect(@editor.line.text).to eq("test #1test #1")
 	end
-	
+
 
 end
-

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -34,7 +34,7 @@ describe RawLine::Editor do
 		@editor.bind(21) { "test #2c" }
 		@editor.bind([22]) { "test #2d" }
 		@editor.terminal.escape_codes = [] # remove any existing escape codes
-		expect {@editor.bind({:test => [?\e.ord, ?t.ord, ?e.ord, ?s.ord, ?t.ord]}) { "test #2e" }}.to raise_error
+		expect {@editor.bind({:test => [?\e.ord, ?t.ord, ?e.ord, ?s.ord, ?t.ord]}) { "test #2e" }}.to raise_error(RawLine::BindingException)
 		@editor.terminal.escape_codes << ?\e.ord
 		expect {@editor.bind({:test => "\etest"}) { "test #2e" }}.to_not raise_error
 		expect {@editor.bind("\etest2") { "test #2f" }}.to_not raise_error

--- a/spec/history_buffer_spec.rb
+++ b/spec/history_buffer_spec.rb
@@ -9,7 +9,7 @@ describe RawLine::HistoryBuffer do
 	end
 
 	it "instantiates an empty array when created" do
-		@history.length.should == 0
+		expect(@history.length).to eq(0)
 	end
 
 	it "allows items to be added to the history" do
@@ -18,15 +18,15 @@ describe RawLine::HistoryBuffer do
 		@history << "line #2"
 		@history << "line #3"
 		@history << "line #2"
-		@history.should == ["line #1", "line #3", "line #2"]
+		expect(@history).to eq(["line #1", "line #3", "line #2"])
 		@history.duplicates = true
 		@history << "line #3"
-		@history.should == ["line #1", "line #3", "line #2", "line #3"]
+		expect(@history).to eq(["line #1", "line #3", "line #2", "line #3"])
 		@history.exclude = lambda { |i| i.match(/line #[456]/) }
 		@history << "line #4"
 		@history << "line #5"
 		@history << "line #6"
-		@history.should == ["line #1", "line #3", "line #2", "line #3"]	
+		expect(@history).to eq(["line #1", "line #3", "line #2", "line #3"])
 	end
 
 	it "does not overflow" do
@@ -36,13 +36,13 @@ describe RawLine::HistoryBuffer do
 		@history << "line #4"
 		@history << "line #5"
 		@history << "line #6"
-		@history.length.should == 5
+		expect(@history.length).to eq(5)
 	end
 
 	it "allows navigation back and forward" do
 		@history.back
 		@history.forward
-		@history.position.should == nil
+		expect(@history.position).to eq(nil)
 		@history << "line #1"
 		@history << "line #2"
 		@history << "line #3"
@@ -53,36 +53,36 @@ describe RawLine::HistoryBuffer do
 		@history.back
 		@history.back
 		@history.back
-		@history.position.should == 0
+		expect(@history.position).to eq(0)
 		@history.back
-		@history.position.should == 0
+		expect(@history.position).to eq(0)
 		@history.forward
-		@history.position.should == 1
-		@history.forward
-		@history.forward
+		expect(@history.position).to eq(1)
 		@history.forward
 		@history.forward
-		@history.position.should == 4
 		@history.forward
-		@history.position.should == 4
+		@history.forward
+		expect(@history.position).to eq(4)
+		@history.forward
+		expect(@history.position).to eq(4)
 		@history.cycle = true
 		@history.forward
 		@history.forward
-		@history.position.should == 1
+		expect(@history.position).to eq(1)
 	end
 
 	it "can retrieve the last element or the element at @position via 'get'" do
-		@history.get.should == nil
+		expect(@history.get).to eq(nil)
 		@history << "line #1"
 		@history << "line #2"
 		@history << "line #3"
 		@history << "line #4"
 		@history << "line #5"
-		@history.get.should == "line #5"
+		expect(@history.get).to eq("line #5")
 		@history.back
-		@history.get.should == "line #4"
+		expect(@history.get).to eq("line #4")
 		@history.forward
-		@history.get.should == "line #5"
+		expect(@history.get).to eq("line #5")
 	end
 
 	it "can be cleared and resized" do
@@ -93,14 +93,14 @@ describe RawLine::HistoryBuffer do
 		@history << "line #5"
 		@history.back
 		@history.back
-		@history.get.should == "line #4"
+		expect(@history.get).to eq("line #4")
 		@history.resize(6)
-		@history.position.should == nil
+		expect(@history.position).to eq(nil)
 		@history << "line #6"
-		@history.get.should == "line #6"
+		expect(@history.get).to eq("line #6")
 		@history.empty
-		@history.should == []
-		@history.size.should == 6
-		@history.position.should == nil
+		expect(@history).to eq([])
+		expect(@history.size).to eq(6)
+		expect(@history.position).to eq(nil)
 	end
 end

--- a/spec/line_spec.rb
+++ b/spec/line_spec.rb
@@ -15,43 +15,43 @@ describe RawLine::Line do
 	it "allows characters to be added to @text via the '<<' operator" do
 		@line.text = "test #1"
 		@line << 'a'[0]
-		@line.text.should == "test #1a"
+		expect(@line.text).to eq("test #1a")
 	end
 
 	it "allows characters to be retrieved and substituted via '[]' and '[]=' operators" do
 		@line.text = 'test #2'
 		@line[0] = 't'
-		@line[0..3].should == 'test'
+		expect(@line[0..3]).to eq('test')
 		@line[4..6] = ''
 		@line[0] = "This is a t"
-		@line.text.should == "This is a test"
+		expect(@line.text).to eq("This is a test")
 	end
 
 	it "updates @position via 'left' and 'right'" do
 		@line.text = "test #3"
 		@line.right 2
-		@line.position.should == 2
+		expect(@line.position).to eq(2)
 		@line.left
-		@line.position.should == 1
+		expect(@line.position).to eq(1)
 		@line.left 4
-		@line.position.should == 0
+		expect(@line.position).to eq(0)
 		@line.right HighLine::SystemExtensions.terminal_size()[0]+10
-		@line.position.should == HighLine::SystemExtensions.terminal_size()[0]-2
-		@line.eol.should == 6
+		expect(@line.position).to eq(HighLine::SystemExtensions.terminal_size()[0]-2)
+		expect(@line.eol).to eq(6)
 	end
 
 	it "is aware of the word in which the cursor is" do
 		@line.text = "This is another test"
-		@line.word.should == {:start => 0, :end => 3, :text => "This"}
+		expect(@line.word).to eq({:start => 0, :end => 3, :text => "This"})
 		@line.right 2
-		@line[2].should == 'i'[0]
-		@line.word.should == {:start => 0, :end => 3, :text => "This"}
+		expect(@line[2]).to eq('i'[0])
+		expect(@line.word).to eq({:start => 0, :end => 3, :text => "This"})
 		@line.right
-		@line.word.should == {:start => 0, :end => 3, :text => "This"}
+		expect(@line.word).to eq({:start => 0, :end => 3, :text => "This"})
 		@line.right
-		@line.word.should == {:start => 0, :end => 3, :text => "This"}
+		expect(@line.word).to eq({:start => 0, :end => 3, :text => "This"})
 		@line.right
-		@line.word.should == {:start => 5, :end => 6, :text => "is"}
+		expect(@line.word).to eq({:start => 5, :end => 6, :text => "is"})
 	end
 
 end


### PR DESCRIPTION
This updates Highline and RSpec dependencies. 
- HighLine 1.7.2 fixes [this bug](https://github.com/JEG2/highline/pull/139/files) which is pretty important for RawLine to be used successfully on *nix boxes
- Use RSpec 3 and remove all deprecation warnings due to syntax changes by updating the syntax. Basically changing all `thing.should == other_thing` to be `expect(thing).to eq(other_thing)`
